### PR TITLE
Fixes #2 by increasing maven api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.0</version>
+      <version>3.3.9</version>
     </dependency>
     <dependency>
       <groupId>rhino</groupId>
@@ -94,6 +94,14 @@
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <source>1.5</source>
+              <target>1.5</target>
+            </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
When trying to compile with Maven 3.3.3 you would get

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project maven-js-formatter-plugin: Compilation failure
[ERROR] /C:/source/github/maven-js-formatter-plugin/src/main/java/com/github/formatter/JSBeautifier.java:[170,35] cannot access org.codehaus.plexus.logging.LogEnabled
[ERROR] class file for org.codehaus.plexus.logging.LogEnabled not found

after investigating it looked like some incompatibility between the
maven-api dependency and the later version of maven due to upgrading the
dependency fixes the issue.

I have tested compiling with apache-maven-2.2.1 and still works okay however needed to specify JDK version 1.5 in compiler plugin
